### PR TITLE
Fix LibLouis binaries missing for Mac AARCH64

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@ child.project.url.inherit.append.path="false">
         <logback-classic.version>1.5.15</logback-classic.version>
         <icu4j.version>72.1</icu4j.version>
         <mathcat4j.version>0.6.4-12</mathcat4j.version>
-        <jlouis.version>d8570182bd99f812412a9869387347a837fd9c5b</jlouis.version>
+        <jlouis.version>c75db74718cea465f839f7cb5b4bcf716ba3e3e3</jlouis.version>
         <libembosser.version>1.4.3</libembosser.version>
         <jaxbapi.version>4.0.2</jaxbapi.version>
         <jaxbruntime.version>4.0.5</jaxbruntime.version>


### PR DESCRIPTION
This updates to a version of JLouis which includes binaries for Mac AARCH64 enabling users to run BrailleBlaster-NG on Mac silicon.