### PR TITLE
Fixed issue where ASCIIMath feature did not work

### DIFF
--- a/brailleblaster-app/src/dist/conveyor.conf
+++ b/brailleblaster-app/src/dist/conveyor.conf
@@ -42,7 +42,7 @@ app {
     }
     linux.options += "-Dtruffle.attach.library="<libpath>"/libtruffleattach.so"
     mac.options += "-Dtruffle.attach.library="<libpath>"/libtruffleattach.dylib"
-    windows.options += "-Dtruffle.attach.library"<libpath>"\\truffleattach.dll"
+    windows.options += "-Dtruffle.attach.library="<libpath>"\\truffleattach.dll"
   }
   icons = "icon.png"
   file-associations = [ .bbz ]

--- a/brailleblaster-app/src/dist/conveyor.conf
+++ b/brailleblaster-app/src/dist/conveyor.conf
@@ -40,6 +40,9 @@ app {
       jlouis.library.path = <libpath>
       mathcat.library.path = <libpath>
     }
+    linux.options += "-Dtruffle.attach.library="<libpath>"/libtruffleattach.so"
+    mac.options += "-Dtruffle.attach.library="<libpath>"/libtruffleattach.dylib"
+    windows.options += "-Dtruffle.attach.library"<libpath>"\\truffleattach.dll"
   }
   icons = "icon.png"
   file-associations = [ .bbz ]


### PR DESCRIPTION
This fixes issue #12 where GraalVM could not find the truffle attach library. This caused ASCIIMath to fail.