### PR TITLE
Fix issue with error reporting where all submitted reports fail

### DIFF
--- a/brailleblaster-core/src/main/java/org/brailleblaster/perspectives/mvc/modules/misc/ExceptionReportingModule.kt
+++ b/brailleblaster-core/src/main/java/org/brailleblaster/perspectives/mvc/modules/misc/ExceptionReportingModule.kt
@@ -194,6 +194,7 @@ object ExceptionReportingModule /*implements SimpleListener*/ {
                 .put("exception", ExceptionUtils.getStackTrace(exception))
                 .put("description", description ?: "")
                 .put("versionBb", Project.BB.version)
+                .put("versionUtd", "Unknown")
                 .put("versionJLouis", "Unknown")
                 .put(
                     "versionLibLouis",


### PR DESCRIPTION
The server expects the versionUtd parameter when submitting the report. As UTD is now not separately versioned we set this to Unknown now.