### PR TITLE
Downgrade PanDoc to 3.6.3 for Mac AARCH64

### DIFF
--- a/brailleblaster-app/pom.xml
+++ b/brailleblaster-app/pom.xml
@@ -210,7 +210,7 @@
                             <goal>wget</goal>
                         </goals>
                         <configuration>
-                            <url>https://github.com/jgm/pandoc/releases/download/${pandoc.version}/pandoc-${pandoc.version}-arm64-macOS.zip</url>
+                            <url>https://github.com/jgm/pandoc/releases/download/3.6.3/pandoc-3.6.3-arm64-macOS.zip</url>
                             <unpack>true</unpack>
                             <includes>
                                 <include>**/pandoc</include>

--- a/brailleblaster-app/src/dist/conveyor.conf
+++ b/brailleblaster-app/src/dist/conveyor.conf
@@ -82,7 +82,7 @@ app {
       }
     }
     aarch64 {
-      info-plist.LSMinimumSystemVersion = 15.0.0
+      info-plist.LSMinimumSystemVersion = 14.0.0
       inputs += "native/mac-aarch64/lib/*.jar"
       inputs += {
         from = "native/mac-aarch64"

--- a/brailleblaster-core/src/main/java/org/brailleblaster/archiver2/PandocArchiverLoader.kt
+++ b/brailleblaster-core/src/main/java/org/brailleblaster/archiver2/PandocArchiverLoader.kt
@@ -21,7 +21,7 @@ import org.brailleblaster.pandoc.FixImage
 import org.brailleblaster.pandoc.FixMathML
 import org.brailleblaster.pandoc.FixNestedList
 import org.brailleblaster.pandoc.Fixer
-import org.brailleblaster.utils.OS
+import org.brailleblaster.util.PANDOC_CMD
 import org.slf4j.LoggerFactory
 import java.io.*
 import java.nio.charset.StandardCharsets
@@ -60,17 +60,17 @@ object PandocArchiverLoader : ArchiverFactory.FileLoader {
 
     override val extensionsAndDescription: ImmutableMap<String, String>
         get() {
-        return ImmutableMap.Builder<String, String>()
-            .put("*.docx", "Microsoft Word Files (*.docx)")
-            .put("*.epub", "Epub Books (*.epub)")
-            .put("*.htm", "HTML Files (*.htm)")
-            .put("*.html", "HTML Files (*.html)")
-            .put("*.xhtml;*.xhtm;*.xht", "XHTML Files (*.xhtml;*.xhtm;*.xht)")
-            .put("*.md", "Markdown Files (*.md)")
-            .put("*.odt", "Open Document Files (*.odt)")
-            .put("*.tex", "LaTeX files (*.tex)")
-            .build()
-    }
+            return ImmutableMap.Builder<String, String>()
+                .put("*.docx", "Microsoft Word Files (*.docx)")
+                .put("*.epub", "Epub Books (*.epub)")
+                .put("*.htm", "HTML Files (*.htm)")
+                .put("*.html", "HTML Files (*.html)")
+                .put("*.xhtml;*.xhtm;*.xht", "XHTML Files (*.xhtml;*.xhtm;*.xht)")
+                .put("*.md", "Markdown Files (*.md)")
+                .put("*.odt", "Open Document Files (*.odt)")
+                .put("*.tex", "LaTeX files (*.tex)")
+                .build()
+        }
 
     @Throws(Exception::class)
     private fun pandocImport(filename: String, fromFormat: String?): Pair<String, String> {
@@ -93,23 +93,18 @@ object PandocArchiverLoader : ArchiverFactory.FileLoader {
         val fileTabName = "$newFilename.bbz"
         newFilename = "$newFilename-"
 
-        // determine the os and executable to use
-        val cmd = BBIni.nativeBinPath.resolve(when(org.brailleblaster.utils.os) {
-            OS.Windows -> "pandoc.exe"
-                else -> "pandoc"
-        }).absolutePathString()
 
         // set the working dir and execute
         try {
             wrkDir = File(PANDOCLUA)
-            env[0] = "PANDOCCMD=$cmd"
+            env[0] = "PANDOCCMD=$PANDOC_CMD"
             val outFile = File.createTempFile("bb-$outFilename-pandoc-err-", ".txt")
             outFile.deleteOnExit()
             val bbFile = File.createTempFile(newFilename, ".bbx")
             bbFile.deleteOnExit()
             newFilename = bbFile.absolutePath
             val pb = ProcessBuilder(
-                cmd, "--from=$fromFormat",
+                PANDOC_CMD, "--from=$fromFormat",
                 "--to=bbx.lua",
                 "--output=" + bbFile.absolutePath,
                 filename
@@ -118,7 +113,7 @@ object PandocArchiverLoader : ArchiverFactory.FileLoader {
                 .redirectError(ProcessBuilder.Redirect.INHERIT)
                 .redirectErrorStream(true)
                 .redirectOutput(outFile)
-            pb.environment()["PANDOCCMD"] = cmd
+            pb.environment()["PANDOCCMD"] = PANDOC_CMD
             var logStr = "\n***** PandocArchiverLoader *****\n"
             logStr = """
                 $logStr${pb.command()}

--- a/brailleblaster-core/src/main/java/org/brailleblaster/userHelp/VersionInfo.kt
+++ b/brailleblaster-core/src/main/java/org/brailleblaster/userHelp/VersionInfo.kt
@@ -19,6 +19,7 @@ package org.brailleblaster.userHelp
 import com.sun.jna.Platform
 import org.apache.commons.lang3.SystemUtils
 import org.brailleblaster.AppProperties
+import org.brailleblaster.util.PANDOC_VERSION
 import org.mwhapples.jlouis.Louis
 import java.io.IOException
 import java.util.*
@@ -27,7 +28,7 @@ import java.util.*
  * Loads build properties file Jenkins inserts into the jar files before distributing in the maven
  * repository
  */
-private val ALL_PROJECTS = listOf(Project.BB, Project.LIBLOUIS)
+private val ALL_PROJECTS = listOf(Project.BB, Project.LIBLOUIS, Project.PANDOC)
 
 val versionsSimple: String
     get() = createSummaryString { obj: Project -> generateVersionsShort(obj) }
@@ -68,6 +69,15 @@ sealed interface Project {
         override val displayName: String = "LibLouis"
         override val version: String by lazy {
             LIBLOUIS_INSTANCE.version
+        }
+        override val versionWithRev: String
+            get() = version
+        override val date: String? = null
+    }
+    data object PANDOC : Project {
+        override val displayName: String = "PanDoc"
+        override val version: String by lazy {
+            PANDOC_VERSION
         }
         override val versionWithRev: String
             get() = version

--- a/brailleblaster-core/src/main/java/org/brailleblaster/util/PanDoc.kt
+++ b/brailleblaster-core/src/main/java/org/brailleblaster/util/PanDoc.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2025 Michael Whapples
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.brailleblaster.util
+
+import org.brailleblaster.BBIni
+import org.brailleblaster.utils.OS
+import org.brailleblaster.utils.os
+import kotlin.io.path.absolutePathString
+
+val PANDOC_CMD: String by lazy {
+    BBIni.nativeBinPath.resolve(
+        when (os) {
+            OS.Windows -> "pandoc.exe"
+            else -> "pandoc"
+        }
+    ).absolutePathString()
+}
+
+val PANDOC_VERSION: String by lazy {
+    var version = "Unknown"
+    val p = Runtime.getRuntime().exec(arrayOf(PANDOC_CMD, "--version"))
+    if (p.waitFor() == 0)  {
+        val firstLine = p.inputReader(Charsets.UTF_8).readLines().firstOrNull()
+        if (firstLine != null) {
+            version = firstLine.split(' ').last()
+        }
+    }
+    version
+}

--- a/pom.xml
+++ b/pom.xml
@@ -93,6 +93,7 @@ child.project.url.inherit.append.path="false">
         <commonsexec.version>1.3</commonsexec.version>
         <commonscollections4.version>4.5.0-M1</commonscollections4.version>
         <jna.version>5.16.0</jna.version>
+        <!-- Note that Mac AARCH64 does not use this as users do not like how 3.6.4 pushed to MacOSX 15. -->
         <pandoc.version>3.6.4</pandoc.version>
         <orgeclipseswtbotswtfinder.version>f5b2edaee2</orgeclipseswtbotswtfinder.version>
     </properties>


### PR DESCRIPTION
By making this downgrade BrailleBlaster-NG will now run on MacOSX 14. The downgrade is only done for Mac AARCH64 as all other users do not need this and may benefit from the newer PanDoc.