### PR TITLE
Fix issue with Mac not being able to cancel quit

### DIFF
--- a/brailleblaster-core/src/main/java/org/brailleblaster/perspectives/mvc/menu/MenuManager.kt
+++ b/brailleblaster-core/src/main/java/org/brailleblaster/perspectives/mvc/menu/MenuManager.kt
@@ -142,7 +142,7 @@ object MenuManager {
         ) { e: Event -> AboutTool.run(BBSelectionData(e.widget, WPManager.getInstance())) }
         addSystemMenuItem(
             shellMenu.display, SWT.ID_QUIT
-        ) { WPManager.getInstance().close() }
+        ) { it.doit = WPManager.getInstance().close() }
         addSystemMenuItem(
             shellMenu.display, SWT.ID_PREFERENCES
         ) { BrailleSettingsDialog(WPManager.getInstance().controller, PagePropertiesTab::class.java) }


### PR DESCRIPTION
This fixes issue #28 where it is not possible to cancel quit on the Mac. This is a trial fix, once confirmed definitely working we can look at removing the mitigations like removing the cancel button from the save prompt.