### PR TITLE
Remove coroutines

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,6 @@ child.project.url.inherit.append.path="false">
         <kotlin.version>2.1.21</kotlin.version>
         <kotlin.compiler.incremental>true</kotlin.compiler.incremental>
         <serialization.version>1.8.0</serialization.version>
-        <kotlinx.coroutines.version>1.10.1</kotlinx.coroutines.version>
         <jetbrains.annotations.version>24.1.0</jetbrains.annotations.version>
         <eclipse.collections.version>12.0.0.M3</eclipse.collections.version>
         <slf4j.version>2.0.16</slf4j.version>
@@ -243,10 +242,6 @@ child.project.url.inherit.append.path="false">
             <artifactId>kotlin-stdlib</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jetbrains.kotlinx</groupId>
-            <artifactId>kotlinx-coroutines-core</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.eclipse.collections</groupId>
             <artifactId>eclipse-collections-api</artifactId>
         </dependency>
@@ -330,31 +325,6 @@ child.project.url.inherit.append.path="false">
                 <groupId>org.jetbrains.kotlinx</groupId>
                 <artifactId>kotlinx-serialization-json</artifactId>
                 <version>${serialization.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jetbrains.kotlinx</groupId>
-                <artifactId>kotlinx-coroutines-core</artifactId>
-                <version>${kotlinx.coroutines.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.jetbrains.kotlin</groupId>
-                        <artifactId>kotlin-stdlib</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.jetbrains.kotlin</groupId>
-                        <artifactId>kotlin-stdlib-common</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>org.jetbrains.kotlinx</groupId>
-                <artifactId>kotlinx-coroutines-core-jvm</artifactId>
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.jetbrains.kotlin</groupId>
-                        <artifactId>kotlin-stdlib-jdk8</artifactId>
-                    </exclusion>
-                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.jetbrains.kotlin</groupId>


### PR DESCRIPTION
This removes the dependency on Kotlin coroutines, these were not actually being used and it seems unlikely they will be used anytime soon.