### PR TITLE
Make binary builds use Java24

### DIFF
--- a/brailleblaster-app/src/dist/conveyor.conf
+++ b/brailleblaster-app/src/dist/conveyor.conf
@@ -1,4 +1,4 @@
-include required("/stdlib/jdk/21/amazon.conf")
+include required("/stdlib/jdk/24/amazon.conf")
 include required("https://raw.githubusercontent.com/hydraulic-software/conveyor/master/configs/jvm/extract-native-libraries.conf")
 include required(file("about.properties"))
 
@@ -34,6 +34,7 @@ app {
     modules += java.sql
     modules += jdk.zipfs
     file-encoding = UTF-8
+    options += "--enable-native-access=ALL-UNNAMED"
     mac.options += "-XstartOnFirstThread"
     extract-native-libraries = true
     system-properties {


### PR DESCRIPTION
Binary builds such as those in releases should be built with (java24. This is needed in preparation for embedding GraalVM.