### PR TITLE
Update the jeuclid dependency so batik dependencies also get updated.

### DIFF
--- a/brailleblaster-core/pom.xml
+++ b/brailleblaster-core/pom.xml
@@ -13,8 +13,7 @@
     <properties>
         <!-- Versioning -->
         <miglayoutswt.version>11.3</miglayoutswt.version>
-        <jeuclid.version>3.1.14</jeuclid.version>
-
+        <jeuclid.version>c79273c782dbaccafafb5f92b53f353dbe52218d</jeuclid.version>
         <xmlgraphicscommons.version>2.8</xmlgraphicscommons.version>
 
         <!-- For exec:java, put here so mainClass can be overridden with -Dexec.mainClass -->
@@ -125,7 +124,7 @@
         </dependency>
         <dependency>
             <!-- This was last updated in 2010, so we need to exclude its outdated dependencies -->
-            <groupId>de.rototor.jeuclid</groupId>
+            <groupId>com.github.mwhapples.jeuclid</groupId>
             <artifactId>jeuclid-core</artifactId>
             <version>${jeuclid.version}</version>
             <exclusions>


### PR DESCRIPTION
There were security warnings about some of the dependencies pulled in by jeuclid. This updates jeuclid so we have greater control over it.