### PR TITLE
Update PanDoc to 3.8.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@ child.project.url.inherit.append.path="false">
         <orgeclipseswtbotswtfinder.version>f5b2edaee2</orgeclipseswtbotswtfinder.version>
 
         <!-- Note that Mac does not use this as users do not like how 3.6.4 pushed to MacOSX 15. -->
-        <pandoc.version>3.8.2.1</pandoc.version>
+        <pandoc.version>3.8.3</pandoc.version>
         <pandoc.version.mac>3.6.3</pandoc.version.mac>
     </properties>
 


### PR DESCRIPTION
This updates PanDoc to 3.8.3. Again there is the exclusion for the Mac due to the minimum OS version the update would bring.