### PR TITLE
Remove spell check menu item

### DIFF
--- a/brailleblaster-core/src/main/java/org/brailleblaster/perspectives/braille/CoreModulesFactory.kt
+++ b/brailleblaster-core/src/main/java/org/brailleblaster/perspectives/braille/CoreModulesFactory.kt
@@ -55,7 +55,7 @@ class CoreModulesFactory : ModuleFactory {
         add(FontSizeModule)
         add(PageNumberDialog(manager.wpManager.shell))
         add(SearchDialog(manager.wpManager.shell, 0))
-        add(SpellCheckTool)
+        // add(SpellCheckTool)
         addAll(NavigateModule.tools)
         add(CorrectTranslationDialog(manager.wpManager.shell, SWT.APPLICATION_MODAL))
         add(SixKeyModeModule(manager))


### PR DESCRIPTION
The spell check tool has not been active for a very long time and realistically it will not be made active anytime soon. Therefore is it not useful to keep it showing in the menu.