### PR TITLE
Move spell check to a separate module.

### DIFF
--- a/brailleblaster-core/src/main/java/org/brailleblaster/perspectives/braille/CoreModulesFactory.kt
+++ b/brailleblaster-core/src/main/java/org/brailleblaster/perspectives/braille/CoreModulesFactory.kt
@@ -15,7 +15,6 @@
  */
 package org.brailleblaster.perspectives.braille
 
-import org.brailleblaster.perspectives.braille.spellcheck.SpellCheckTool
 import org.brailleblaster.perspectives.braille.ui.CellTabTool
 import org.brailleblaster.perspectives.braille.ui.CorrectTranslationDialog
 import org.brailleblaster.perspectives.braille.ui.contractionRelaxer.ContractionRelaxer
@@ -55,7 +54,6 @@ class CoreModulesFactory : ModuleFactory {
         add(FontSizeModule)
         add(PageNumberDialog(manager.wpManager.shell))
         add(SearchDialog(manager.wpManager.shell, 0))
-        // add(SpellCheckTool)
         addAll(NavigateModule.tools)
         add(CorrectTranslationDialog(manager.wpManager.shell, SWT.APPLICATION_MODAL))
         add(SixKeyModeModule(manager))

--- a/brailleblaster-spellcheck-tools/pom.xml
+++ b/brailleblaster-spellcheck-tools/pom.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.brailleblaster</groupId>
+        <artifactId>brailleblaster-parent</artifactId>
+        <version>${revision}${sha1}${changelist}</version>
+    </parent>
+
+    <artifactId>brailleblaster-spellcheck-tools</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.brailleblaster</groupId>
+            <artifactId>brailleblaster-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.brailleblaster</groupId>
+            <artifactId>utils</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.platform</groupId>
+            <artifactId>org.eclipse.swt.${swt.platform}</artifactId>
+            <version>${swt.version}</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/brailleblaster-spellcheck-tools/src/main/kotlin/org/brailleblaster/spellcheck/SpellCheckManager.kt
+++ b/brailleblaster-spellcheck-tools/src/main/kotlin/org/brailleblaster/spellcheck/SpellCheckManager.kt
@@ -13,7 +13,7 @@
  * You should have received a copy of the GNU General Public License along
  * with this program. If not, see <https://www.gnu.org/licenses/>.
  */
-package org.brailleblaster.perspectives.braille.spellcheck
+package org.brailleblaster.spellcheck
 
 import org.apache.commons.lang3.exception.ExceptionUtils
 import org.brailleblaster.BBIni

--- a/brailleblaster-spellcheck-tools/src/main/kotlin/org/brailleblaster/spellcheck/SpellCheckModuleFactory.kt
+++ b/brailleblaster-spellcheck-tools/src/main/kotlin/org/brailleblaster/spellcheck/SpellCheckModuleFactory.kt
@@ -1,0 +1,9 @@
+package org.brailleblaster.spellcheck
+
+import org.brailleblaster.perspectives.braille.Manager
+import org.brailleblaster.perspectives.mvc.BBSimpleManager
+import org.brailleblaster.spi.ModuleFactory
+
+class SpellCheckModuleFactory : ModuleFactory {
+    override fun createModules(manager: Manager): Iterable<BBSimpleManager.SimpleListener> = listOf(SpellCheckTool)
+}

--- a/brailleblaster-spellcheck-tools/src/main/kotlin/org/brailleblaster/spellcheck/SpellCheckView.kt
+++ b/brailleblaster-spellcheck-tools/src/main/kotlin/org/brailleblaster/spellcheck/SpellCheckView.kt
@@ -13,7 +13,7 @@
  * You should have received a copy of the GNU General Public License along
  * with this program. If not, see <https://www.gnu.org/licenses/>.
  */
-package org.brailleblaster.perspectives.braille.spellcheck
+package org.brailleblaster.spellcheck
 
 import org.brailleblaster.utils.localization.LocaleHandler.Companion.getDefault
 import org.brailleblaster.util.Notify

--- a/brailleblaster-spellcheck-tools/src/main/kotlin/org/brailleblaster/spellcheck/SpellChecker.kt
+++ b/brailleblaster-spellcheck-tools/src/main/kotlin/org/brailleblaster/spellcheck/SpellChecker.kt
@@ -13,7 +13,7 @@
  * You should have received a copy of the GNU General Public License along
  * with this program. If not, see <https://www.gnu.org/licenses/>.
  */
-package org.brailleblaster.perspectives.braille.spellcheck
+package org.brailleblaster.spellcheck
 
 import org.brailleblaster.BBIni
 import org.brailleblaster.utils.Architecture

--- a/brailleblaster-spellcheck-tools/src/main/kotlin/org/brailleblaster/spellcheck/Tokenizer.kt
+++ b/brailleblaster-spellcheck-tools/src/main/kotlin/org/brailleblaster/spellcheck/Tokenizer.kt
@@ -13,7 +13,7 @@
  * You should have received a copy of the GNU General Public License along
  * with this program. If not, see <https://www.gnu.org/licenses/>.
  */
-package org.brailleblaster.perspectives.braille.spellcheck
+package org.brailleblaster.spellcheck
 
 class Tokenizer {
     private var text: String

--- a/brailleblaster-spellcheck-tools/src/main/resources/META-INF/services/org.brailleblaster.spi.ModuleFactory
+++ b/brailleblaster-spellcheck-tools/src/main/resources/META-INF/services/org.brailleblaster.spi.ModuleFactory
@@ -1,0 +1,1 @@
+org.brailleblaster.spellcheck.SpellCheckModuleFactory

--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,7 @@ child.project.url.inherit.append.path="false">
         <module>brailleblaster-updater</module>
         <module>utd-cli</module>
         <module>brailleblaster-math-tools</module>
+        <module>brailleblaster-spellcheck-tools</module>
     </modules>
 
     <properties>


### PR DESCRIPTION
Moving the spell check to a separate module means that whilst not enabled we need not include the code in a release build.