### PR TITLE
Add BrailleBlaster-NG to the Windows Store

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ BrailleBlaster is a free, open-source Braille transcription program developed by
 
 ## Obtaining BrailleBlaster-NG
 
-The latest release of BrailleBlaster-NG can be downloaded from the [download page](https://download.brailleblaster-ng.app/download.html). Older releases are archived on the project's [GitHub Releases page](https://github.com/mwhapples/BrailleBlaster-NG/releases).
+The latest release of BrailleBlaster-NG can be downloaded from the [download page](https://download.brailleblaster-ng.app/download.html). Alternatively Windows users can get BrailleBlaster-NG from the [Windows Store](https://apps.microsoft.com/detail/9P3KHJWK7730). Older releases are archived on the project's [GitHub Releases page](https://github.com/mwhapples/BrailleBlaster-NG/releases).
 
 Users who want to be on the bleeding edge and are prepared to take the risks of using development builds may wish to try out the [continuous release](https://github.com/mwhapples/brailleblaster-ng/releases/continuous). See the below details for running a development build.
 

--- a/brailleblaster-app/src/dist/conveyor.conf
+++ b/brailleblaster-app/src/dist/conveyor.conf
@@ -25,6 +25,7 @@ app {
       "-brailleblaster-nix.sh"
       "-conveyor.conf"
       "-output/**"
+      "-windows-store.conf"
     ]
   }
   jvm {

--- a/brailleblaster-app/src/dist/windows-store.conf
+++ b/brailleblaster-app/src/dist/windows-store.conf
@@ -1,0 +1,14 @@
+include required(file("conveyor.conf"))
+
+app {
+  windows {
+    store {
+      identity-name = "MichaelWhapples.BrailleBlaster-NG"
+      publisher = "CN=D95C7845-687D-44E0-A6CC-9DC60B92F231"
+      publisher-display-name = "Michael Whapples"
+      store-id = "9P3KHJWK7730"
+    }
+    signing-key = "derived"
+    certificate = "self signed by "${app.windows.store.publisher}
+  }
+}


### PR DESCRIPTION
BrailleBlaster-NG is now available in the Windows Store and the README has been updated and conveyor config has been included.