### PR TITLE
Update Mac pandoc to match other platforms

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@ child.project.url.inherit.append.path="false">
 
         <!-- Note that Mac does not use this as users do not like how 3.6.4 pushed to MacOSX 15. -->
         <pandoc.version>3.8.3</pandoc.version>
-        <pandoc.version.mac>3.6.3</pandoc.version.mac>
+        <pandoc.version.mac>3.8.3</pandoc.version.mac>
     </properties>
 
 


### PR DESCRIPTION
This brings the PanDoc used on mac to 3.8.3 which makes it match that of the other supported platforms.