### PR TITLE
Do not include pom artifacts in builds

### DIFF
--- a/brailleblaster-app/pom.xml
+++ b/brailleblaster-app/pom.xml
@@ -192,10 +192,10 @@
                                 org.eclipse.swt.win32.win32.x86_64,
                                 org.eclipse.swt.gtk.linux.x86_64,
                                 org.eclipse.swt.gtk.linux.aarch64,
-                                org.eclipse.swt.cocoa.macosx.x86_64
+                                org.eclipse.swt.cocoa.macosx.x86_64,
                                 org.eclipse.swt.cocoa.macosx.aarch64
                             </excludeArtifactIds>
-                            <excludeTypes>zip</excludeTypes>
+                            <excludeTypes>zip,pom</excludeTypes>
                             <includeScope>runtime</includeScope>
                         </configuration>
                     </execution>

--- a/utd/src/main/java/org/brailleblaster/utd/actions/GenericBlockAction.kt
+++ b/utd/src/main/java/org/brailleblaster/utd/actions/GenericBlockAction.kt
@@ -99,9 +99,8 @@ open class GenericBlockAction : GenericAction(), IBlockAction {
             val inText = input.text
             translateText.append(inText)
             endPos.add(translateText.length)
-            val set = input.emphasis
             var value = Louis.TypeForms.PLAIN_TEXT
-            for (type in set) {
+            for (type in input.emphasis) {
                 value = (value.toInt() or type.jlouisTypeform.toInt()).toShort()
             }
 
@@ -121,12 +120,9 @@ open class GenericBlockAction : GenericAction(), IBlockAction {
             }
             emphVal.toShort()
         }.toShortArray()
-        var wordFlag: Boolean
-        var puncFlag: Boolean
-        var puncStart: Int
-        wordFlag = false
-        puncFlag = false
-        puncStart = 0
+        var wordFlag = false
+        var puncFlag = false
+        var puncStart = 0
         var emphasis: Short = 0
         var preWordEmp: Short = 0
         var wordCount = 0


### PR DESCRIPTION
When creating a distribution build we do not need to copy the pom artifacts as these are not useful or used in the distribution.